### PR TITLE
fix typo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -193,7 +193,7 @@ fn backtrack_from(picross: &mut Picross, start_row: usize) -> bool {
     false
 }
 
-/// Fills picross with the first solution at finds.
+/// Fills picross with the first solution it finds.
 /// If no solution is found, picross is left untouched.
 /// Returns whether a solution has been found.
 fn backtrack(picross: &mut Picross) -> bool {


### PR DESCRIPTION
This reverts commit 531f18d0f9dd7fff0e45400dd56add12357e427e.

Pas de bol, le premier essai était le bon :p
