### PR TITLE
Use code moved to picross to precompute all possible rows. Optimization: *3

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,117 +11,6 @@ use sfml::system::Vector2f;
 use sfml::window::{ContextSettings, VideoMode, event, Close};
 use sfml::graphics::{RenderWindow, RenderTarget, RectangleShape, Color};
 
-/// Iterator yielding all increasing series from 0..n to 0..size
-/// Ex: if size==3 and n==2, the iterator yield
-/// ```
-/// vec![0,1], vec[0,2], vec[1,2]
-/// ```
-/// This iterator should be created with gen_increasing_series
-struct IncreasingSeriesGenerator {
-    n: usize,
-    size: usize,
-    series: Vec<usize>,
-    already_started: bool,
-}
-
-impl Iterator for IncreasingSeriesGenerator {
-    type Item = Vec<usize>;
-    fn next(&mut self) -> Option<Vec<usize>> {
-        if !self.already_started {
-            self.already_started = true;
-            return Some(self.series.clone());
-        }
-
-        let mut i = self.n - 1;
-        loop {
-            if self.series[i] < (if i == self.n - 1 {self.size} else {self.series[i+1]}) - 1 {
-                // on peut incrémenter cet indice safely
-                break
-            }
-            if i == 0 {
-                // itérateur terminé
-                return None;
-            }
-            i -= 1;
-        }
-        self.series[i] += 1;
-        for j in i+1..self.n {
-            self.series[j] = self.series[j-1] + 1;
-        }
-        return Some(self.series.clone())
-    }
-}
-
-/// Constructor for IncreasingSeriesGenerator
-/// This function returns an iterator yielding all increasing series from 0..n to 0..size
-/// ```
-/// for series in gen_increasing_series(2, 3) {
-///     // row will be successively vec![0,1], vec[0,2], vec[1,2]
-/// }
-/// ```
-fn gen_increasing_series(n: usize, size: usize) -> IncreasingSeriesGenerator {
-    IncreasingSeriesGenerator {
-        n: n,
-        size: size,
-        series: (0..n).collect(),
-        already_started: false,
-    }
-}
-
-fn inc_series_to_row(series: &Vec<usize>, spec: &Vec<usize>, row_size: usize) -> Vec<Cell> {
-    let mut row = Vec::with_capacity(row_size);
-    let mut cur_pos = 0; // position dans series
-    for (i_block, &pos) in series.iter().enumerate() {
-        for _ in cur_pos..pos {
-            row.push(Cell::White);
-        }
-        cur_pos = pos;
-        for _ in 0..spec[i_block] {
-            row.push(Cell::Black);
-        }
-        cur_pos += 1;
-        if row.len() != row_size {
-            row.push(Cell::White);
-        }
-    }
-    for _ in row.len()..row_size {
-        row.push(Cell::White);
-    }
-    row
-}
-
-/// Iterator yielding all possible picross rows following the given constraints
-/// It should be created with gen_picross_row
-struct PicrossRowGenerator<'a> {
-    /// size of the row
-    row_size : usize,
-    /// specification of the blocks : &vec![1,2] means a one-cell block and a two-cell block
-    spec : &'a Vec<usize>,
-    inc_series_gen : IncreasingSeriesGenerator,
-}
-
-impl<'a> Iterator for PicrossRowGenerator<'a> {
-    type Item = Vec<Cell>;
-
-    fn next(&mut self) -> Option<Vec<Cell>> {
-        match self.inc_series_gen.next() {
-            Some(vec) => Some(inc_series_to_row(&vec, self.spec, self.row_size)),
-            None => None
-        }
-    }
-}
-
-/// Returns an iterator yielding all possible picross rows following the given constraints :
-/// row_size: size of the row
-/// spec: specification of the blocks : &vec![1,2] means a one-cell block and a two-cell block
-fn gen_picross_rows<'a>(row_size: usize, spec: &'a Vec<usize>) -> PicrossRowGenerator {
-    PicrossRowGenerator {
-        row_size: row_size,
-        spec: spec,
-        inc_series_gen: gen_increasing_series(spec.len(), row_size + 1 - spec.iter().fold(0, |sum, x| sum + x))
-    }
-}
-
 fn is_consistent(picross: &Picross) -> bool {
     for col in 0..picross.length {
         let mut num_block = 0;
@@ -179,8 +68,8 @@ fn is_row_consistent_with(old: &Vec<Cell>, new: &Vec<Cell>) -> bool {
         })
 }
 
-fn gcd<T> (start_row: &Vec<Cell>, mut possible_rows: T) -> (Vec<Cell>, bool) where T: Iterator<Item=Vec<Cell>> {
-    let mut gcd = possible_rows.find(|row| is_row_consistent_with(start_row, row)).expect("No solution to this picross");
+fn gcd<'a, T> (start_row: &Vec<Cell>, mut possible_rows: T) -> (Vec<Cell>, bool) where T: Iterator<Item=&'a Vec<Cell>> {
+    let mut gcd = possible_rows.find(|row| is_row_consistent_with(start_row, row)).expect("No solution to this picross").clone();
     for row in possible_rows {
         if is_row_consistent_with(start_row, &row) {
             for pair in (&mut gcd).iter_mut().zip(row.iter()) {
@@ -197,8 +86,8 @@ fn gcd<T> (start_row: &Vec<Cell>, mut possible_rows: T) -> (Vec<Cell>, bool) whe
 
 fn combex_rows(picross: &mut Picross, w: &mut RenderWindow) -> bool {
     let mut dirty = false;
-    for (row, spec) in (0..picross.cells.len()).zip(picross.row_spec.iter()) {
-        let res = gcd(&picross.cells[row], gen_picross_rows(picross.length, spec));
+    for (row_num, row) in (0..picross.cells.len()).enumerate() {
+        let res = gcd(&picross.cells[row], picross.possible_rows[row_num].iter());
         picross.cells[row] = res.0;
         dirty |= res.1;
         if res.1 {
@@ -210,10 +99,9 @@ fn combex_rows(picross: &mut Picross, w: &mut RenderWindow) -> bool {
 
 fn combex_cols(picross: &mut Picross, w: &mut RenderWindow) -> bool {
     let mut dirty = false;
-    let col_spec = picross.col_spec.iter().cloned().collect::<Vec<Vec<usize>>>();
-    for (i, (column, spec)) in picross.transpose().iter().zip(col_spec).enumerate() {
-        let res = gcd(&column, gen_picross_rows(picross.height, &spec));
-        picross.set_col(i, res.0);
+    for (col_num, col) in picross.transpose().iter().enumerate() {
+        let res = gcd(&col, picross.possible_cols[col_num].iter());
+        picross.set_col(col_num, res.0);
         dirty |= res.1;
         if res.1 {
             draw(w, &picross);
@@ -228,10 +116,11 @@ fn backtrack_from(picross: &mut Picross, start_row: usize, w: &mut RenderWindow)
     }
     let original_row = picross.cells[start_row].clone();
     let unknown_original_row = original_row.iter().all(|x| x == &Cell::Unknown);
-    for test_row in gen_picross_rows(picross.length, &picross.row_spec[start_row].clone()) {
-        draw(w, &picross);
+    draw(w, &picross); // Do not draw *every* backtracking, to save time due to vertical sync
+                       // To draw every step, just move this line into the for loop
+    for test_row in picross.possible_rows[start_row].clone().iter() {
         if unknown_original_row || is_row_consistent_with(&original_row, &test_row) {
-            picross.cells[start_row] = test_row;
+            picross.cells[start_row] = test_row.clone();
             if is_consistent(picross) {
                 if backtrack_from(picross, start_row + 1, w) {
                     return true;
@@ -250,7 +139,9 @@ fn backtrack(picross: &mut Picross, w: &mut RenderWindow) -> bool {
     while combex_rows(picross, w) | combex_cols(picross, w) {
         draw(w, &picross);
     }
-    backtrack_from(picross, 0, w)
+    backtrack_from(picross, 0, w);
+    draw(w, &picross);
+    true
 }
 
 /// Draws `Picross` `p` to `RenderWindow` `w`
@@ -300,6 +191,7 @@ fn main() {
     for test_file in read_dir("../data").unwrap() {
         let f = File::open(test_file.unwrap().path()).unwrap();
         let mut picross = Picross::parse(&mut BufReader::new(f).lines().map(|x| x.unwrap()));
+        picross.fill_possibles();
         assert_eq!(picross.length, picross.cells[0].len());
         assert_eq!(picross.height, picross.cells.len());
         backtrack(&mut picross, &mut window);


### PR DESCRIPTION
 Use code moved to picross to precompute all possible rows

Also reduce displaying too-fast-for-the-eye states
